### PR TITLE
corrected format for per unit in category Pizza

### DIFF
--- a/data.json
+++ b/data.json
@@ -198,7 +198,10 @@
         "tags": ["carbohydrate", "protein"],
         "category": "Pizza",
         "metrics": [{
-            "per": "1 unit",
+            "per": {
+                    "amount":1,
+                    "unit": "pizza"
+            },
             "use": {
                 "amount": 1239,
                 "unit": "litres water"


### PR DESCRIPTION
Unlike other objects within the file, "per" was structured as a string rather than an object in Pizza's metrics (line 200 onwards).