### PR TITLE
minor typo in Danish translation for 'tea'

### DIFF
--- a/translations/da-DK.po
+++ b/translations/da-DK.po
@@ -92,7 +92,7 @@ msgid "sheep meat"
 msgstr "lammekød"
 
 msgid "tea"
-msgstr "the"
+msgstr "te"
 
 msgid "tomato"
 msgstr "tomat"


### PR DESCRIPTION
was showing as `the`, corrected to `te`. 